### PR TITLE
Verify Content

### DIFF
--- a/content.go
+++ b/content.go
@@ -99,6 +99,9 @@ func makeContent(data, file io.Reader, author string) (created monketype.Content
 		return
 	}
 
+	var inspectBuffer *bytes.Buffer = new(bytes.Buffer)
+	file = io.TeeReader(file, inspectBuffer)
+
 	var file_url string
 	if file_url, err = upload(file); err != nil {
 		return

--- a/content_test.go
+++ b/content_test.go
@@ -86,7 +86,10 @@ func mustLocalMultipart(method, path string, data []byte) (request *http.Request
 		panic(err)
 	}
 
-	filePart.Write([]byte("haha yes I am a file"))
+	filePart.Write([]byte{
+		0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, // png file header
+		104, 97, 104, 97, 32, 121, 101, 115, 32, 73, 32, 97, 109, 32, 97, 32, 112, 110, 103, // haha yes I am a png
+	})
 	if err = writer.Close(); err != nil {
 		panic(err)
 	}

--- a/content_test.go
+++ b/content_test.go
@@ -133,50 +133,41 @@ func Test_postContent(test *testing.T) {
 	var set []byte
 	var sets [][]byte = [][]byte{
 		mustMarshal(map[string]interface{}{
-			"mime":       "png",
 			"featurable": false,
 			"nsfw":       false,
 			"tags":       []string{"some", "tags"},
 		}),
 		mustMarshal(map[string]interface{}{
-			"mime":       "png",
 			"featurable": false,
 			"nsfw":       true,
 			"tags":       []string{"some", "tags"},
 		}),
 		mustMarshal(map[string]interface{}{
-			"mime":       "png",
 			"featurable": true,
 			"nsfw":       false,
 			"tags":       []string{"some", "tags"},
 		}),
 		mustMarshal(map[string]interface{}{
-			"mime":       "png",
 			"featurable": true,
 			"nsfw":       true,
 			"tags":       []string{"some", "tags"},
 		}),
 		mustMarshal(map[string]interface{}{
-			"mime":       "png",
 			"featurable": true,
 			"nsfw":       true,
 			"tags":       []string{},
 		}),
 		mustMarshal(map[string]interface{}{
-			"mime":       "png",
 			"featurable": true,
 			"nsfw":       true,
 			"tags":       make([]string, 0),
 		}),
 		mustMarshal(map[string]interface{}{
-			"mime":       "png",
 			"featurable": true,
 			"nsfw":       true,
 			"tags":       nil,
 		}),
-		mustMarshal(map[string]interface{}{
-			"mime": "png",
-		}),
+		mustMarshal(map[string]interface{}{}),
 	}
 
 	var request *http.Request
@@ -219,15 +210,6 @@ func Test_postContent(test *testing.T) {
 func Test_postContent_badrequest(test *testing.T) {
 	var set []byte
 	var sets [][]byte = [][]byte{
-		mustMarshal(map[string]interface{}{
-			"featurable": true,
-			"nsfw":       true,
-			"tags":       []string{"tag"},
-		}),
-		mustMarshal(map[string]interface{}{
-			"featurable": true,
-			"nsfw":       true,
-		}),
 		[]byte("Why do they call him Donkey Kong if he's a gorilla"),
 		make([]byte, 0),
 	}

--- a/go.mod
+++ b/go.mod
@@ -7,5 +7,5 @@ require (
 	github.com/imonke/monkebase v0.0.0-20201112031310-8b05081cb292
 	github.com/imonke/monkelib v0.0.0-20201112033513-60ad84f0ad9f
 	github.com/imonke/monketype v0.0.0-20201111232752-19268649a84b
-	golang.org/x/crypto v0.0.0-20201112155050-0c6587e931a9 // indirect
+	golang.org/x/crypto v0.0.0-20201117144127-c1f2f97bffc9 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -61,7 +61,11 @@ golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201112155050-0c6587e931a9 h1:umElSU9WZirRdgu2yFHY0ayQkEnKiOC1TtM3fWXFnoU=
 golang.org/x/crypto v0.0.0-20201112155050-0c6587e931a9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20201117144127-c1f2f97bffc9 h1:phUcVbl53swtrUN8kQEXFhUxPlIlWyBfKmidCu7P95o=
+golang.org/x/crypto v0.0.0-20201117144127-c1f2f97bffc9/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/types.go
+++ b/types.go
@@ -13,7 +13,6 @@ type CreateContentBody struct {
 
 func (_ CreateContentBody) Validators() (values map[string]func(interface{}) (bool, error)) {
 	values = map[string]func(interface{}) (bool, error){
-		"mime":       groudon.ValidString,
 		"nsfw":       groudon.ValidBool,
 		"featurable": groudon.ValidBool,
 		"tags":       groudon.ValidStringSlice,


### PR DESCRIPTION
Verify that uploaded things are images. Currently, this allows content of type `png`, `webp`, and `jpeg/jpg`
Because the mime is determined while inspecting the content, the `mime` field in the json portion of the request is no longer useful